### PR TITLE
chore(ci): replace deprecated gha commands and actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,5 +11,5 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: golangci/golangci-lint-action@v2
+      - uses: actions/checkout@v4
+      - uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Release
         env:
           GOPROXY: proxy.golang.org
-        run: go list -m "github.com/ryanwholey/go-pihole@${GITHUB_REF#refs/*/}"
+        run: go list -m "github.com/awaybreaktoday/lib-pihole-go@${GITHUB_REF#refs/*/}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         tag:
-          - "2025.03.0"
+          - "2025.08.0"
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ryanwholey/go-pihole
+module github.com/awaybreaktoday/lib-pihole-go
 
 go 1.22
 


### PR DESCRIPTION
Just a version bump of the github action commands