### PR TITLE
feat: add API token auth and TTL-aware DNS/CNAME support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,62 @@ Requires Pi-hole Web Interface >= `6`. For <6, use tag <= v0.0.4
 ## Usage
 
 ```go
-import "github.com/awaybreaktoday/go-pihole"
+import (
+	"context"
+	"errors"
+	"log"
+	"os"
 
-client := pihole.New(pihole.Config{
-	BaseURL:  "http://pi.hole"
-	Password: "token"
+	"github.com/awaybreaktoday/go-pihole"
+)
+
+client, err := pihole.New(pihole.Config{
+	BaseURL:  "https://pi.hole/api",
+	APIToken: os.Getenv("PIHOLE_API_TOKEN"),
+	// Password remains supported for session logins when no API token is provided.
+	Password: os.Getenv("PIHOLE_PASSWORD"),
 })
+if err != nil {
+	log.Fatal(err)
+}
 
 record, err := client.LocalDNS.Create(context.Background(), "my-domain.com", "127.0.0.1")
 if err != nil {
 	log.Fatal(err)
 }
+log.Printf("%s -> %s (ttl=%d comment=%q)", record.Domain, record.IP, record.TTL, record.Comment)
+
+alias, err := client.LocalCNAME.CreateRecord(context.Background(), &pihole.CNAMERecord{
+	Domain: "www.example.com",
+	Target: "example.com",
+	TTL:    3600,
+	HasTTL: true,
+})
+if err != nil {
+	log.Fatal(err)
+}
+log.Printf("%s -> %s (ttl=%d)", alias.Domain, alias.Target, alias.TTL)
+
+_, err = client.LocalDNS.Create(context.Background(), record.Domain, record.IP)
+if err != nil {
+	var dnsErr *pihole.DNSAPIError
+	if errors.As(err, &dnsErr) {
+		log.Printf("pihole rejected request: key=%s message=%s", dnsErr.Key, dnsErr.Message)
+	}
+}
 ```
+
+### Authentication
+
+`Config` accepts either `APIToken` or `APIKey` to enable Pi-hole's API token authentication. When supplied, the client automatically sends the `X-FTL-APIKEY` header and skips session negotiation. Supplying `Password` continues to work for legacy session-based flows, providing a fallback when no token is present.
+
+### DNS and CNAME helpers
+
+- `DNSRecord` now exposes optional `TTL` and `Comment` fields so callers can observe and persist Pi-hole's additional metadata.
+- `CNAMERecord` tracks whether a TTL is supplied (`HasTTL`) and retains Pi-hole's original tuple, ensuring deletes round-trip exactly what the server expects.
+- Use `LocalCNAME.CreateRecord` to submit a structured `CNAMERecord` and include TTLs when required.
+
+Mutation helpers in both packages return typed errors (`*DNSAPIError`, `*CNAMEAPIError`) that surface Pi-hole's structured `error.key`, `message`, and `hint` values for improved diagnostics.
 
 ## Test
 

--- a/api_errors.go
+++ b/api_errors.go
@@ -1,0 +1,87 @@
+package pihole
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type apiErrorDetails struct {
+	Key     string      `json:"key"`
+	Message string      `json:"message"`
+	Hint    interface{} `json:"hint"`
+}
+
+type apiErrorPayload struct {
+	Error *apiErrorDetails `json:"error"`
+}
+
+func parseAPIError(body []byte) (*apiErrorDetails, error) {
+	if len(body) == 0 {
+		return nil, fmt.Errorf("empty response body")
+	}
+
+	var payload apiErrorPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+
+	if payload.Error == nil {
+		return nil, fmt.Errorf("missing error payload")
+	}
+
+	return payload.Error, nil
+}
+
+type DNSAPIError struct {
+	StatusCode int
+	Key        string
+	Message    string
+	Hint       interface{}
+}
+
+func (e *DNSAPIError) Error() string {
+	if e == nil {
+		return ""
+	}
+
+	if e.Key != "" {
+		return fmt.Sprintf("pi-hole DNS API error (%d %s): %s", e.StatusCode, e.Key, e.Message)
+	}
+
+	return fmt.Sprintf("pi-hole DNS API error (%d): %s", e.StatusCode, e.Message)
+}
+
+type CNAMEAPIError struct {
+	StatusCode int
+	Key        string
+	Message    string
+	Hint       interface{}
+}
+
+func (e *CNAMEAPIError) Error() string {
+	if e == nil {
+		return ""
+	}
+
+	if e.Key != "" {
+		return fmt.Sprintf("pi-hole CNAME API error (%d %s): %s", e.StatusCode, e.Key, e.Message)
+	}
+
+	return fmt.Sprintf("pi-hole CNAME API error (%d): %s", e.StatusCode, e.Message)
+}
+
+func newDNSAPIError(status int, body []byte) error {
+	if details, err := parseAPIError(body); err == nil {
+		return &DNSAPIError{StatusCode: status, Key: details.Key, Message: details.Message, Hint: details.Hint}
+	}
+
+	return fmt.Errorf("received unexpected status code %d %s", status, string(body))
+}
+
+func newCNAMEAPIError(status int, body []byte) error {
+	if details, err := parseAPIError(body); err == nil {
+		return &CNAMEAPIError{StatusCode: status, Key: details.Key, Message: details.Message, Hint: details.Hint}
+	}
+
+	return fmt.Errorf("received unexpected status code %d %s", status, string(body))
+}

--- a/test_transport.go
+++ b/test_transport.go
@@ -1,0 +1,21 @@
+package pihole
+
+import (
+	"io"
+	"net/http"
+	"strings"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newHTTPResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}


### PR DESCRIPTION
Added API-token support, TTL-aware DNS/CNAME handling, and structured error reporting so the client matches Pi-hole’s latest API.

- client.go:18-144 now accepts APIToken/APIKey, caches it on the client, and skips password logins while still falling back to session auth when needed.
- local_dns.go:36-195 extends DNSRecord with TTL, HasTTL, Comment, and parses optional metadata; errors bubble up as *DNSAPIError via the new newDNSAPIError.
- local_cname.go:15-212 introduces CNAMERecord.HasTTL, keeps the original tuple for deletes, and exposes CreateRecord so callers can supply TTLs; responses map to
  *CNAMEAPIError.
- api_errors.go:8-87 centralises Pi-hole error parsing and defines the typed DNS/CNAME error wrappers.
- test_transport.go:9-20, client_test.go:32-65, local_dns_test.go:14-153, and local_cname_test.go:19-208 add transport stubs plus unit coverage for TTL parsing, tuple  preservation, and error propagation.
- README.md:9-65 documents API-token configuration, TTL-aware helpers, and the new error types.